### PR TITLE
Building Docker container doesn't work as Ubuntu Disco is no longer supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:disco
+FROM ubuntu:bionic
 
 # Install packages required to build AsteroidOS
-RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python2 python3 wget shared-mime-info
+RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python python3 wget shared-mime-info
 
 # Add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images
 RUN apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
I'm following the building tutorial at https://asteroidos.org/wiki/building-asteroidos/, trying to build with docker.

The first step is to create the docker image from the Dockerfile, however this fails as the Dockerfile is based on Ubuntu Disco, which is no longer supported (apt-get fails, as it can't update the repositories)

I already made some progress updating it myself, but don't have it fully working.
By changing the base image from Ubuntu Disco to Ubuntu Focal apt-get can update the repositories correctly.
Next installing python2 fails. Replacing python2 with python (which in ubuntu focal is still python2) fixes that.

Installing some packages requires user interaction, which isn't possible when building a docker image. This is fixed by setting the environment variable `DEBIAN_FRONTEND=noninteractive`

Now the docker image can be built, however when trying to build AsteroidOS in this docker image I get the following error while building qemu (Full log attached below):
```|   LINK    mips-linux-user/qemu-mips
| /asteroid/build/tmp-glibc/hosttools/ld.bfd: linux-user/syscall.o: in function `do_syscall1':
| /asteroid/build/tmp-glibc/work/x86_64-linux/qemu-native/3.1.1.1-r0/qemu-3.1.1.1/linux-user/syscall.c:7404: undefined reference to `stime'
| collect2: error: ld returned 1 exit status
| make[1]: *** [Makefile:199: qemu-mips] Error 1
| make: *** [Makefile:483: subdir-mips-linux-user] Error 2
|   CC      aarch64-linux-user/trace/generated-helpers.o
|   LINK    aarch64-linux-user/qemu-aarch64
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_compile (log file is located at /asteroid/build/tmp-glibc/work/x86_64-linux/qemu-native/3.1.1.1-r0/temp/log.do_compile.643877)
ERROR: Task (/asteroid/src/oe-core/meta/recipes-devtools/qemu/qemu-native_3.1.1.1.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 735 tasks of which 0 didn't need to be rerun and 1 failed.
```
[log.do_compile.643877.log](https://github.com/AsteroidOS/asteroid/files/4677171/log.do_compile.643877.log)

This has probably to do with glibc update 2.31 (https://sourceware.org/legacy-ml/libc-announce/2020/msg00001.html), which says
> * The obsolete function stime is no longer available to newly linked
  binaries, and its declaration has been removed from <time.h>.
  Programs that set the system time should use clock_settime instead.

This has been addressed by qemu in commit 0f1f2d4596ae (https://git.qemu.org/?p=qemu.git;a=commit;h=0f1f2d4596ae), which isn't included in the qemu release used here yet (3.1.1.1).

As far as I can see there would be two ways to fix this: link against an older glibc version or upgrade the qemu version., however I'm not experienced enough with the AsteroidOS build system to fix this. Any help would be appreciated.