### PR TITLE
Add repository for smelt(Moto 360 2015)

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -86,6 +86,7 @@ else
     clone_dir src/meta-sparrow-hybris  https://github.com/AsteroidOS/meta-sparrow-hybris     master
     clone_dir src/meta-sprat-hybris    https://github.com/AsteroidOS/meta-sprat-hybris       master
     clone_dir src/meta-sturgeon-hybris https://github.com/AsteroidOS/meta-sturgeon-hybris    master
+    clone_dir src/meta-smelt-hybris    https://github.com/AsteroidOS/meta-smelt-hybris       master
     clone_dir src/meta-swift-hybris    https://github.com/AsteroidOS/meta-swift-hybris       master
     clone_dir src/meta-tetra-hybris    https://github.com/AsteroidOS/meta-tetra-hybris       master
     clone_dir src/meta-wren-hybris     https://github.com/AsteroidOS/meta-wren-hybris        master
@@ -121,6 +122,7 @@ BBLAYERS = " \
   ${SRCDIR}/meta-dory-hybris \
   ${SRCDIR}/meta-lenok-hybris \
   ${SRCDIR}/meta-sturgeon-hybris \
+  ${SRCDIR}/meta-smelt-hybris \
   ${SRCDIR}/meta-mtk6580-hybris \
   ${SRCDIR}/meta-mooneye-hybris \
   ${SRCDIR}/meta-swift-hybris \


### PR DESCRIPTION
smelt has two things that differ from all the current supported watches:
- flat tire
- edges of touchscreen aren't very sensitive(close app doesn't work properly)

To fix these issues changes are required to qml-asteroid(https://github.com/AsteroidOS/qml-asteroid/pull/10) and asteroid-launcher(https://github.com/AsteroidOS/asteroid-launcher/pull/40).
Currently it is setup such that the machine config can set the flat tire size and adjust the edge sensitivity.(https://github.com/MagneFire/meta-smelt-hybris/blob/master/conf/machine/smelt.conf)
This needs another patch for meta-asteroid(https://github.com/AsteroidOS/meta-asteroid/pull/41).

Another small bug with the smelt platform is that the boot logo isn't displayed on boot. It can be fixed with `msm-fb-refresher` but that breaks the compositor. See https://github.com/MagneFire/meta-smelt-hybris/issues/1 for more info on the issue.

And don't forget https://github.com/AsteroidOS/meta-smelt-hybris needs some stuff :wink: 