### PR TITLE
Enable backslash escapes for printing help

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -18,15 +18,15 @@ declare -a devices=("anthias" "bass" "dory" "harmony" "inharmony" "lenok" "moone
 
 function printNoDeviceInfo {
     echo "Usage:"
-    echo "Updating the sources:\t$ . ./prepare-build.sh update"
-    echo "Building AsteroidOS:\t$ . ./prepare-build.sh device\n"
-    echo "Available devices:\n"
+    echo -e "Updating the sources:\t$ . ./prepare-build.sh update"
+    echo -e "Building AsteroidOS:\t$ . ./prepare-build.sh device\n"
+    echo -e "Available devices:\n"
 
     for device in ${devices[*]}; do
         echo "$device"
     done
 
-    echo "\nWiki - Building AsteroidOS: https://asteroidos.org/wiki/building-asteroidos/"
+    echo -e "\nWiki - Building AsteroidOS: https://asteroidos.org/wiki/building-asteroidos/"
 
     return 1
 }


### PR DESCRIPTION
Previously, `echo` was run without the `-e` flag, which enables
backslash escapes. For at least the GNU coreutils version of echo, this
is required to substitute "\t" for a tab character and "\n" for a
newline character. (However, it does appear to work either way with
`zsh`, which has `echo` as a shell builtin that appears to always
respect escapes.)

Before:
```
chandler@asteroidos-build:~/asteroid$ . prepare-build.sh
Usage:
Updating the sources:\t$ . ./prepare-build.sh update
Building AsteroidOS:\t$ . ./prepare-build.sh device\n
Available devices:\n
anthias
bass
dory
harmony
inharmony
lenok
mooneye
smelt
sparrow
sprat
sturgeon
swift
tetra
wren
\nWiki - Building AsteroidOS: https://asteroidos.org/wiki/building-asteroidos/
chandler@asteroidos-build:~/asteroid$
```

After:
```
chandler@asteroidos-build:~/asteroid$ . prepare-build.sh
Usage:
Updating the sources:	$ . ./prepare-build.sh update
Building AsteroidOS:	$ . ./prepare-build.sh device

Available devices:

anthias
bass
dory
harmony
inharmony
lenok
mooneye
smelt
sparrow
sprat
sturgeon
swift
tetra
wren

Wiki - Building AsteroidOS: https://asteroidos.org/wiki/building-asteroidos/
chandler@asteroidos-build:~/asteroid$
```