### PR TITLE
Bump all to Honister.

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -101,11 +101,11 @@ else
     fi
 
     # Fetch all the needed layers in src/
-    clone_dir src/oe-core                   https://github.com/openembedded/openembedded-core.git hardknott
-    clone_dir src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           2021-04.1-hardknott
-    clone_dir src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git hardknott
-    clone_dir src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  hardknott
-    clone_dir src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   hardknott f5e0379951d32f01da229ecb017b885d618aa82c
+    clone_dir src/oe-core                   https://github.com/openembedded/openembedded-core.git honister
+    clone_dir src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           1.52
+    clone_dir src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git honister
+    clone_dir src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  honister
+    clone_dir src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   honister
     clone_dir src/meta-asteroid             https://github.com/AsteroidOS/meta-asteroid           master
     clone_dir src/meta-asteroid-community   https://github.com/AsteroidOS/meta-asteroid-community master
     clone_dir src/meta-anthias-hybris       https://github.com/AsteroidOS/meta-anthias-hybris     master


### PR DESCRIPTION
This PR along with the following brings support for Yocto Honister.
- https://github.com/AsteroidOS/meta-asteroid/pull/68
- https://github.com/AsteroidOS/meta-sturgeon-hybris/pull/21
- https://github.com/AsteroidOS/meta-bass-hybris/pull/18
- https://github.com/AsteroidOS/meta-dory-hybris/pull/14
- https://github.com/AsteroidOS/meta-lenok-hybris/pull/16
- https://github.com/AsteroidOS/meta-mooneye-hybris/pull/5
- https://github.com/AsteroidOS/meta-mtk6580-hybris/pull/22
- https://github.com/AsteroidOS/meta-sawfish-hybris/pull/5
- https://github.com/AsteroidOS/meta-smelt-hybris/pull/15
- https://github.com/AsteroidOS/meta-sparrow-hybris/pull/10
- https://github.com/AsteroidOS/meta-sprat-hybris/pull/3
- https://github.com/AsteroidOS/meta-swift-hybris/pull/11
- https://github.com/AsteroidOS/meta-tetra-hybris/pull/18
- https://github.com/AsteroidOS/meta-wren-hybris/pull/10
- https://github.com/AsteroidOS/meta-anthias-hybris/pull/6
- https://github.com/AsteroidOS/meta-asteroid-community/pull/4

It has been tested on `sturgeon` and confirmed that it builds (not tested) for `mooneye` (for gcc 8 kernel compilation tests) and `harmony` (for `gst-droid` tests) as they diverge a bit from the standard structure that all the other watches follow.