### PR TITLE
Move meta-qt5 back to the honister branch.

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -104,7 +104,7 @@ else
     clone_dir src/oe-core                   https://github.com/openembedded/openembedded-core.git honister
     clone_dir src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           1.52
     clone_dir src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git honister
-    clone_dir src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  master 05ed1d985e0c514bcf5be1d63ddecb47d439463f
+    clone_dir src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  honister
     clone_dir src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   honister
     clone_dir src/meta-asteroid             https://github.com/AsteroidOS/meta-asteroid           master
     clone_dir src/meta-asteroid-community   https://github.com/AsteroidOS/meta-asteroid-community master


### PR DESCRIPTION
The SailfishOS related remote changes have been merged to the honister branch.
It's safe now to continue using the branch again.

The pleasant side effect of this is that we now move the Qt base from 5.15.2 to 5.15.3.