### PR TITLE
Add machine for beluga (OPPO Watch 41mm/46mm)

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -14,7 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-declare -a devices=("anthias" "bass" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "mooneye" "narwhal" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "wren")
+declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "mooneye" "narwhal" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "wren")
 
 function printNoDeviceInfo {
     echo "Usage:"


### PR DESCRIPTION
Support for the OPPO Watch has been added recently (https://github.com/AsteroidOS/meta-smartwatch/pull/67).
Add it to the build script too.