### PR TITLE
Support personal clones of subprojects

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -42,15 +42,22 @@ function printNoDeviceInfo {
     return 1
 }
 
+# When updating, if the user has a personal fork of the subproject, and has set the 
+# upstream URL, this will fetch updates from the upstream repository
 function pull_dir {
     if [ -d $1/.git/ ] ; then
         [ "$1" != "." ]   && pushd $1 > /dev/null
         git symbolic-ref HEAD &> /dev/null
         if [ $? -eq 0 ] ; then
             echo -e "\e[32mPulling $1\e[39m"
-            git pull --rebase
+            if git remote get-url upstream > /dev/null
+            then
+                git pull upstream --rebase "$2"
+            else
+                git pull --rebase
+            fi
             [ $? -ne 0 ] && echo -e "\e[91mError pulling $1\e[39m"
-            git checkout $2
+            git checkout "$2"
         else
             echo -e "\e[35mSkipping $1\e[39m"
         fi


### PR DESCRIPTION
When working on AsteroidOS recipes, it's convenient to have both a fork of the subproject and also to set the upstream url.  However, the prepare-build.sh file would then only retrieve updates from the fork rather than upstream.  This addresses that issue by checking whether there is an upstream or not; if not, it does the fork as it always had. If there is an upstream, it pulls the named head from that fork instead, making it easy and reliable to maintain one's own fork for contributions back to the main project.

Signed-off-by: Ed Beroset <beroset@ieee.org>