### PR TITLE
Use a fixed commit for meta-smartphone, add pike, triggerfish.

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -21,7 +21,7 @@ declare -a layers=(
     "src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           2.0"
     "src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git kirkstone"
     "src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  kirkstone"
-    "src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   kirkstone"
+    "src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   kirkstone 038458fd1fe3d946ce084865adb09238c12eaf90"
     "src/meta-asteroid             https://github.com/AsteroidOS/meta-asteroid           master"
     "src/meta-asteroid-community   https://github.com/AsteroidOS/meta-asteroid-community master"
     "src/meta-smartwatch           https://github.com/AsteroidOS/meta-smartwatch.git     master"
@@ -132,7 +132,7 @@ else
         else
             read -a layer <<< "$l"
         fi
-        clone_dir "${layer[@]:0:1}" "${layer[@]:1:1}" "${layer[@]:2:1}"
+        clone_dir "${layer[@]:0:1}" "${layer[@]:1:1}" "${layer[@]:2:1}" "${layer[@]:3:1}"
     done
 
     # Create local.conf and bblayers.conf on first run

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -14,7 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "minnow" "mooneye" "narwhal" "nemo" "pike" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "wren")
+declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "minnow" "mooneye" "narwhal" "nemo" "pike" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "triggerfish" "wren")
 
 declare -a layers=(
     "src/oe-core                   https://github.com/openembedded/openembedded-core.git kirkstone"

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -14,7 +14,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "minnow" "mooneye" "narwhal" "nemo" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "wren")
+declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "inharmony" "lenok" "minnow" "mooneye" "narwhal" "nemo" "pike" "qemux86" "ray" "smelt" "sparrow" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "wren")
 
 declare -a layers=(
     "src/oe-core                   https://github.com/openembedded/openembedded-core.git kirkstone"


### PR DESCRIPTION
Since https://github.com/shr-distribution/meta-smartphone/commit/376fb5ff5f77db611c0b9d6bcfe1886b8b8961d3 most all of our ports fail to compile as they use a specific SRCREV for libhybris. Eventually all ports should use the same SRCREV instead of something custom. This works around the current issue by rolling back `meta-smartphone` until all ports use the same version of libhybris.

This provides a solution to https://github.com/AsteroidOS/asteroid/issues/238.


This also adds the `pike` and `triggerfish` machines, I've marked @dodoradio as the co-author since he worked on those ports.