### PR TITLE
Silence (harmless) errors in pull_dir

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -64,7 +64,7 @@ function pull_dir {
         git symbolic-ref HEAD &> /dev/null
         if [ $? -eq 0 ] ; then
             echo -e "\e[32mPulling $1\e[39m"
-            if git remote get-url upstream > /dev/null
+            if git remote get-url upstream &> /dev/null
             then
                 git pull upstream --rebase "$2"
             else


### PR DESCRIPTION
This prevents useless errors to be printed when calling `prepare-build.sh update`