### PR TITLE
Don't set IFS and avoid problems

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -95,7 +95,7 @@ function clone_dir {
 
 function update_layer_config() {
     # Find all layers under src/meta-smartwatch, remove the src/ prefix, sort alphabetically, and store it in an array.
-    IFS=$'\n' layers_smartwatch=($(find src/meta-smartwatch -mindepth 1 -name "*meta-*" -type d | sed -e 's|src/||' | sort))
+    layers_smartwatch=($(find src/meta-smartwatch -mindepth 1 -name "*meta-*" -type d | sed -e 's|src/||' | sort))
     layers=("${layers_conf[@]}" "${layers_smartwatch[@]}")
     for l in "${layers[@]}"; do
         layer_line="  \${SRCDIR}/${l} \\\\"


### PR DESCRIPTION
Setting IFS globally causes problems as mentioned by voidanix in the Matrix chat.  Specifically, it messes up splitting of words and filenames for subsequent runs of the script.  This avoids that and was tested with both bash and zsh.