### PR TITLE
Consolidate Docker commands for efficient cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:bionic
 
 # Install packages required to build AsteroidOS
-RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python python3 python3-distutils wget shared-mime-info zstd liblz4-tool
+# And add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images
+RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python python3 python3-distutils wget shared-mime-info zstd liblz4-tool locales \
+    && rm -rf /var/lib/apt/lists/* && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-# Add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images
-RUN apt-get install -y locales && rm -rf /var/lib/apt/lists/* && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 WORKDIR /asteroid


### PR DESCRIPTION
This commit merges 'apt' commands and cleanup into one Docker layer. This is crucial because cleanup within the same layer it's created is effective, unlike in separate layers. This change improves Docker image efficiency by reducing the overall size.