### PR TITLE
Update base distribution to focal in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Install packages required to build AsteroidOS
 # And add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images
-RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python python3 python3-distutils wget shared-mime-info zstd liblz4-tool locales \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python3 python3-distutils wget shared-mime-info zstd liblz4-tool locales \
     && rm -rf /var/lib/apt/lists/* && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8


### PR DESCRIPTION
I was trying to build some package using https://wiki.asteroidos.org/index.php/Building_AsteroidOS#Build_with_containers

It complains about old version of python
```
Sorry, python 3.8.0 or later is required for this version of bitbake
```

I have removed python2 and added timezone and dpkg non-interactive mode to avoid need for user interaction