### PR TITLE
Bump all to scarthgap

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -17,11 +17,11 @@
 declare -a devices=("anthias" "bass" "beluga" "catfish" "dory" "firefish" "harmony" "hoki" "koi" "inharmony" "lenok" "minnow" "mooneye" "narwhal" "nemo" "pike" "qemux86" "ray" "smelt" "sparrow" "sparrow-mainline" "sprat" "sturgeon" "sawfish" "skipjack" "swift" "tetra" "triggerfish" "wren")
 
 declare -a layers=(
-    "src/oe-core                   https://github.com/openembedded/openembedded-core.git mickledore"
-    "src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           2.4"
-    "src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git master c5f330bc9ae72989b8f880aa15e738a3c8fce4e7"
-    "src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  mickledore"
-    "src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   mickledore"
+    "src/oe-core                   https://github.com/openembedded/openembedded-core.git scarthgap"
+    "src/oe-core/bitbake           https://github.com/openembedded/bitbake.git           2.8.1"
+    "src/meta-openembedded         https://github.com/openembedded/meta-openembedded.git scarthgap"
+    "src/meta-qt5                  https://github.com/meta-qt5/meta-qt5                  scarthgap"
+    "src/meta-smartphone           https://github.com/shr-distribution/meta-smartphone   scarthgap"
     "src/meta-asteroid             https://github.com/AsteroidOS/meta-asteroid           master"
     "src/meta-asteroid-community   https://github.com/AsteroidOS/meta-asteroid-community master"
     "src/meta-smartwatch           https://github.com/AsteroidOS/meta-smartwatch.git     master"


### PR DESCRIPTION
This PR moves all layers to `scarthgap`:
Other relevant PRs:
- https://github.com/AsteroidOS/meta-asteroid-community/pull/34
- https://github.com/AsteroidOS/meta-asteroid/pull/197
- https://github.com/AsteroidOS/meta-smartwatch/pull/250

One thing to keep in mind is that with this change the rootfs image name has changed adding `.rootfs`. This means that we need to update our instructions on the install pages.

Finally this implements https://github.com/AsteroidOS/asteroid/issues/285.