### PR TITLE
Do not generate an empty bblayers.conf file upon update

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -94,6 +94,9 @@ function clone_dir {
 }
 
 function update_layer_config() {
+    if [ -e build/conf/bblayers.conf ]; then
+        return
+    fi
     # Find all layers under src/meta-smartwatch, remove the src/ prefix, sort alphabetically, and store it in an array.
     layers_smartwatch=($(find src/meta-smartwatch -mindepth 1 -name "*meta-*" -type d | sed -e 's|src/||' | sort))
     layers=("${layers_conf[@]}" "${layers_smartwatch[@]}")


### PR DESCRIPTION
https://github.com/AsteroidOS/asteroid/commit/46339cad318aeb7e364377e7c55f16d5f20943e2 introduced behaviour such that the 'current' state of `bblayers.conf` is copied to a temporary file layers are updated and this bblayers.conf is overwritten with the temporary file generated by `mktemp`.

However, this introduces an issue where an empty `bblayers.conf` is created if the user decides to update layers perior to building (i.e. do `./prepare-build.sh update` first) as the temporary file (created with `mktemp`) is copied without any contents because `bblayers.conf` doesn't exist yet.

This empty file doesn't contain the `layer_line` pattern, so nothing will be appended.

To fix this issue, do not generate an empty `bblayers.conf` file upon update if it doesn't exist.