### PR TITLE
Update dockerfile to use ubuntu-latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:focal
+FROM ubuntu:latest
 
 # Install packages required to build AsteroidOS
 # And add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk chrpath texinfo python3 python3-distutils wget shared-mime-info zstd liblz4-tool locales \
+RUN apt update && apt upgrade -y && apt install -y git build-essential cpio diffstat gawk file chrpath texinfo python3 python3-packaging wget shared-mime-info zstd liblz4-tool locales \
     && rm -rf /var/lib/apt/lists/* && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG en_US.utf8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:noble
 
 # Install packages required to build AsteroidOS
 # And add the en_US.utf8 locale because it is required and not installed by default in minimal Ubuntu images


### PR DESCRIPTION
This updates to the latest ubuntu image.  It also removes the deprecated "python3-distutils" and adds "python3-packaging" and "file" to the list of installed dependencies.  This fixes #299 in which libmce-glib would fail to compile with a Python error "ModuleNotFoundError: No module named 'packaging'"