### PR TITLE
prepare-build: improve shebang portability

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # Copyright (C) 2015 Florent Revest <revestflo@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Since bash is not part of the POSIX specification, but /usr/bin/env is, the package managers of some Linux distributions (such as NixOS) put bash in a location other than /bin but do still have it in the path. For this reason, calling env in this way improves portability and allows the code to work unmodified on such distributions while continuing to work on others.